### PR TITLE
Update values.yaml

### DIFF
--- a/charts/ueransim-gnb/values.yaml
+++ b/charts/ueransim-gnb/values.yaml
@@ -99,6 +99,8 @@ ues:
   key: 465B5CE8B199B49FAA5F0A2EE238A6BC
   op: E8ED289DEBA952E4283B54E88E6183CA
   opType: OPC
+  gnb:
+    hostname: ueransim-gnb
   apnList:
     - type: 'IPv4'
       apn: 'internet'


### PR DESCRIPTION
without providing the gnb hostname, GNB_IP address is not getting resolved and the UEs stub enabled in the ueransim-gnb which triggers the UEs POD crashes with below error in the kubectl logs

GNB_IP: 
Launching ue: nr-ue -c ue.yaml
UERANSIM v3.2.6
terminate called after throwing an instance of 'LibError'
  what():  Bad Inet address: null Network unreachable
/entrypoint.sh: line 41:    15 Aborted                 (core dumped) nr-ue -c ue.yaml $@